### PR TITLE
Set content-type explicitly for S3 uploads

### DIFF
--- a/harpoon.gemspec
+++ b/harpoon.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'public_suffix', '~> 1.4', '>= 1.4.5'
   s.add_runtime_dependency 'colorize', '~> 0.7', '>= 0.7.3'
   s.add_runtime_dependency 'activesupport', '~> 4.1', '>= 4.1.5'
+  s.add_runtime_dependency 'mimemagic', '~> 0.3.2'
   s.homepage    = 'http://www.getharpoon.com'
 end

--- a/lib/harpoon/services/s3.rb
+++ b/lib/harpoon/services/s3.rb
@@ -2,6 +2,7 @@ require "aws-sdk"
 require "uri"
 require "public_suffix"
 require "pathname"
+require "mimemagic"
 
 module Harpoon
   module Services
@@ -66,8 +67,9 @@ module Harpoon
           @options.files.each do |f|
             @logger.debug "Path: #{f}"
             relative_path = Pathname.new(f).relative_path_from(Pathname.new(@options.directory)).to_s
+            content_type = MimeMagic.by_path(relative_path)
             @logger.debug "s3 key: #{relative_path}"
-            primary_bucket.objects[relative_path].write(Pathname.new(f))
+            primary_bucket.objects[relative_path].write(Pathname.new(f), content_type: content_type)
           end
           @logger.info "...done"
         else


### PR DESCRIPTION
This should address https://github.com/mazondo/harpoon/issues/2. Uses the `mimemagic` gem to do a best-guess on the content-type for the given file path.